### PR TITLE
Expand unit tests.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,8 +32,14 @@ jobs:
       run: ./test_scripts/install_deps_github_ubuntu.sh && pip install twine
     - name: Install Package
       run: pip install .
-    - name: Run Tests
-      run: mpirun -np 2 python -c 'import pshmem.test; pshmem.test.run()'
+    - name: Run Serial Test
+      run: MPI_DISABLE=1 python3 -c 'import pshmem.test; pshmem.test.run()'
+    - name: Run MPI Test on 1 Process
+      run: mpirun -np 1 python3 -c 'import pshmem.test; pshmem.test.run()'
+    - name: Run MPI Test on 2 Processes
+      run: mpirun -np 2 python3 -c 'import pshmem.test; pshmem.test.run()'
+    - name: Run MPI Test on 4 Processes
+      run: mpirun -np 4 python3 -c 'import pshmem.test; pshmem.test.run()'
     - name: Build source package
       run: rm -rf dist && python setup.py sdist
     - name: Build wheels

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,11 @@ jobs:
       run: ./test_scripts/install_deps_github_ubuntu.sh
     - name: Install Package
       run: pip3 install .
-    - name: Run Tests
+    - name: Run Serial Test
+      run: MPI_DISABLE=1 python3 -c 'import pshmem.test; pshmem.test.run()'
+    - name: Run MPI Test on 1 Process
+      run: mpirun -np 1 python3 -c 'import pshmem.test; pshmem.test.run()'
+    - name: Run MPI Test on 2 Processes
       run: mpirun -np 2 python3 -c 'import pshmem.test; pshmem.test.run()'
   macos:
     runs-on: macos-latest
@@ -43,5 +47,11 @@ jobs:
       run: ./test_scripts/install_deps_github_macos.sh
     - name: Install Package
       run: pip3 install .
-    - name: Run Tests
+    - name: Run Serial Test
+      run: MPI_DISABLE=1 python3 -c 'import pshmem.test; pshmem.test.run()'
+    - name: Run MPI Test on 1 Process
+      run: mpirun -np 1 python3 -c 'import pshmem.test; pshmem.test.run()'
+    - name: Run MPI Test on 2 Processes
       run: mpirun -np 2 python3 -c 'import pshmem.test; pshmem.test.run()'
+    - name: Run MPI Test on 4 Processes
+      run: mpirun -np 4 python3 -c 'import pshmem.test; pshmem.test.run()'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,8 @@ jobs:
       run: mpirun -np 1 python3 -c 'import pshmem.test; pshmem.test.run()'
     - name: Run MPI Test on 2 Processes
       run: mpirun -np 2 python3 -c 'import pshmem.test; pshmem.test.run()'
+    - name: Run MPI Test on 4 Processes
+      run: mpirun -np 4 python3 -c 'import pshmem.test; pshmem.test.run()'
   macos:
     runs-on: macos-latest
     strategy:

--- a/test_scripts/readme_test.py
+++ b/test_scripts/readme_test.py
@@ -1,0 +1,49 @@
+import numpy as np
+from mpi4py import MPI
+
+from pshmem import MPIShared
+
+comm = MPI.COMM_WORLD
+
+with MPIShared((3, 5), np.float64, comm) as shm:
+    # A copy of the data exists on every node and is initialized to zero.
+    # There is a numpy array "view" of that memory available with slice notation
+    # or by accessing the "data" member:
+    if comm.rank == 0:
+        # You can get a summary of the data by printing it:
+        print("String representation:\n")
+        print(shm)
+        print("\n===== Initialized Data =====")
+    for p in range(comm.size):
+        if p == comm.rank:
+            print("rank {}:\n".format(p), shm.data, flush=True)
+        comm.barrier()
+
+    set_data = None
+    set_offset = None
+    if comm.rank == 0:
+        set_data = np.arange(6, dtype=np.float64).reshape((2, 3))
+        set_offset = (1, 1)
+
+    # The set() method is collective, but the inputs only matter on one rank
+    shm.set(set_data, offset=set_offset, fromrank=0)
+
+    # You can also use the usual '[]' notation.  However, this call must do an
+    # additional pre-communication to detect which process the data is coming from.
+    # And this line is still collective and must be called on all processes:
+    shm[set_offset] = set_data
+
+    # This updated data has now been replicated to the shared memory on all nodes.
+    if comm.rank == 0:
+        print("======= Updated Data =======")
+    for p in range(comm.size):
+        if p == comm.rank:
+            print("rank {}:\n".format(p), shm.data, flush=True)
+        comm.barrier()
+
+    # You can read from the node-local copy of the data from all processes,
+    # using either the "data" member or slice access:
+    if comm.rank == comm.size - 1:
+        print("==== Read-only access ======")
+        print("rank {}: shm[2, 3] = {}".format(comm.rank, shm[2, 3]), flush=True)
+        print("rank {}: shm.data = \n{}".format(comm.rank, shm.data), flush=True)

--- a/test_scripts/test_cibuild.sh
+++ b/test_scripts/test_cibuild.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+
+docker run \
+-it \
+-v $(pwd):/home/pshmem \
+quay.io/pypa/manylinux2014_x86_64:latest \
+/bin/bash
+
+# export PATH=/opt/python/cp38-cp38/bin:${PATH}
+# python3 -m pip install --upgrade pip
+# yum -y update
+# yum -y install mpich-3.2-devel.x86_64 mpich-3.2-autoload.x86_64
+# source /etc/profile.d/modules.sh
+# source /etc/profile.d/mpich-3.2-x86_64.sh


### PR DESCRIPTION
This work:

- Adds MPIShared tests for split communicators and COMM_SELF

- Runs for test configurations in github actions

- Removes confusing `__setitem__` use that supported only
  specifying the offsets rather than the full slice.  This
  was convenient, but non-intuitive since it did not follow
  standard broadcast notation.