### PR TITLE
Allow the data size to be zero

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,9 +41,7 @@ jobs:
     - name: Run MPI Test on 1 Process
       run: mpirun -np 1 python3 -c 'import pshmem.test; pshmem.test.run()'
     - name: Run MPI Test on 2 Processes
-      run: mpirun -np 2 -usize 2 -ppn 2 python3 -c 'import pshmem.test; pshmem.test.run()'
-    - name: Run MPI Test on 4 Processes
-      run: mpirun -np 4 -usize 4 -ppn 4 python3 -c 'import pshmem.test; pshmem.test.run()'
+      run: mpirun -np 2 python3 -c 'import pshmem.test; pshmem.test.run()'
     - name: Build source package
       run: rm -rf dist && python setup.py sdist
     - name: Build wheels

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,10 @@ jobs:
   wheels:
     runs-on: ubuntu-latest
     steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.4.0
+      with:
+        access_token: ${{ github.token }}
     - name: Checkout
       uses: actions/checkout@v2
     - name: Set up Python 3.7

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,9 +37,9 @@ jobs:
     - name: Run MPI Test on 1 Process
       run: mpirun -np 1 python3 -c 'import pshmem.test; pshmem.test.run()'
     - name: Run MPI Test on 2 Processes
-      run: mpirun -np 2 python3 -c 'import pshmem.test; pshmem.test.run()'
+      run: mpirun -np 2 -usize 2 python3 -c 'import pshmem.test; pshmem.test.run()'
     - name: Run MPI Test on 4 Processes
-      run: mpirun -np 4 python3 -c 'import pshmem.test; pshmem.test.run()'
+      run: mpirun -np 4 -usize 4 python3 -c 'import pshmem.test; pshmem.test.run()'
     - name: Build source package
       run: rm -rf dist && python setup.py sdist
     - name: Build wheels

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,9 +37,9 @@ jobs:
     - name: Run MPI Test on 1 Process
       run: mpirun -np 1 python3 -c 'import pshmem.test; pshmem.test.run()'
     - name: Run MPI Test on 2 Processes
-      run: mpirun -np 2 -usize 2 python3 -c 'import pshmem.test; pshmem.test.run()'
+      run: mpirun -np 2 -usize 2 -ppn 2 python3 -c 'import pshmem.test; pshmem.test.run()'
     - name: Run MPI Test on 4 Processes
-      run: mpirun -np 4 -usize 4 python3 -c 'import pshmem.test; pshmem.test.run()'
+      run: mpirun -np 4 -usize 4 -ppn 4 python3 -c 'import pshmem.test; pshmem.test.run()'
     - name: Build source package
       run: rm -rf dist && python setup.py sdist
     - name: Build wheels

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,10 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8]
     steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.4.0
+      with:
+        access_token: ${{ github.token }}
     - name: Checkout
       uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -39,6 +43,10 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8]
     steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.4.0
+      with:
+        access_token: ${{ github.token }}
     - name: Checkout
       uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,9 +30,9 @@ jobs:
     - name: Run MPI Test on 1 Process
       run: mpirun -np 1 python3 -c 'import pshmem.test; pshmem.test.run()'
     - name: Run MPI Test on 2 Processes
-      run: mpirun -np 2 python3 -c 'import pshmem.test; pshmem.test.run()'
+      run: mpirun -np 2 -usize 2 python3 -c 'import pshmem.test; pshmem.test.run()'
     - name: Run MPI Test on 4 Processes
-      run: mpirun -np 4 python3 -c 'import pshmem.test; pshmem.test.run()'
+      run: mpirun -np 4 -usize 4 python3 -c 'import pshmem.test; pshmem.test.run()'
   macos:
     runs-on: macos-latest
     strategy:
@@ -54,6 +54,6 @@ jobs:
     - name: Run MPI Test on 1 Process
       run: mpirun -np 1 python3 -c 'import pshmem.test; pshmem.test.run()'
     - name: Run MPI Test on 2 Processes
-      run: mpirun -np 2 python3 -c 'import pshmem.test; pshmem.test.run()'
+      run: mpirun -np 2 -usize 2 python3 -c 'import pshmem.test; pshmem.test.run()'
     - name: Run MPI Test on 4 Processes
-      run: mpirun -np 4 python3 -c 'import pshmem.test; pshmem.test.run()'
+      run: mpirun -np 4 -usize 4 python3 -c 'import pshmem.test; pshmem.test.run()'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,9 +34,7 @@ jobs:
     - name: Run MPI Test on 1 Process
       run: mpirun -np 1 python3 -c 'import pshmem.test; pshmem.test.run()'
     - name: Run MPI Test on 2 Processes
-      run: mpirun -np 2 -usize 2 -ppn 2 python3 -c 'import pshmem.test; pshmem.test.run()'
-    - name: Run MPI Test on 4 Processes
-      run: mpirun -np 4 -usize 4 -ppn 4 python3 -c 'import pshmem.test; pshmem.test.run()'
+      run: mpirun -np 2 python3 -c 'import pshmem.test; pshmem.test.run()'
   macos:
     runs-on: macos-latest
     strategy:
@@ -62,6 +60,4 @@ jobs:
     - name: Run MPI Test on 1 Process
       run: mpirun -np 1 python3 -c 'import pshmem.test; pshmem.test.run()'
     - name: Run MPI Test on 2 Processes
-      run: mpirun -np 2 -usize 2 -ppn 2 python3 -c 'import pshmem.test; pshmem.test.run()'
-    - name: Run MPI Test on 4 Processes
-      run: mpirun -np 4 -usize 4 -ppn 4 python3 -c 'import pshmem.test; pshmem.test.run()'
+      run: mpirun -np 2 python3 -c 'import pshmem.test; pshmem.test.run()'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,9 +30,9 @@ jobs:
     - name: Run MPI Test on 1 Process
       run: mpirun -np 1 python3 -c 'import pshmem.test; pshmem.test.run()'
     - name: Run MPI Test on 2 Processes
-      run: mpirun -np 2 -usize 2 python3 -c 'import pshmem.test; pshmem.test.run()'
+      run: mpirun -np 2 -usize 2 -ppn 2 python3 -c 'import pshmem.test; pshmem.test.run()'
     - name: Run MPI Test on 4 Processes
-      run: mpirun -np 4 -usize 4 python3 -c 'import pshmem.test; pshmem.test.run()'
+      run: mpirun -np 4 -usize 4 -ppn 4 python3 -c 'import pshmem.test; pshmem.test.run()'
   macos:
     runs-on: macos-latest
     strategy:
@@ -54,6 +54,6 @@ jobs:
     - name: Run MPI Test on 1 Process
       run: mpirun -np 1 python3 -c 'import pshmem.test; pshmem.test.run()'
     - name: Run MPI Test on 2 Processes
-      run: mpirun -np 2 -usize 2 python3 -c 'import pshmem.test; pshmem.test.run()'
+      run: mpirun -np 2 -usize 2 -ppn 2 python3 -c 'import pshmem.test; pshmem.test.run()'
     - name: Run MPI Test on 4 Processes
-      run: mpirun -np 4 -usize 4 python3 -c 'import pshmem.test; pshmem.test.run()'
+      run: mpirun -np 4 -usize 4 -ppn 4 python3 -c 'import pshmem.test; pshmem.test.run()'

--- a/pshmem/shmem.py
+++ b/pshmem/shmem.py
@@ -266,7 +266,7 @@ class MPIShared(object):
         check_result = np.zeros((self._procs,), dtype=np.int32)
         if value is not None:
             check_rank[self._rank] = 1
-        self._comm.Allreduce(check_rank, check_result, op=MPI.SUM)
+        self._comm.Allreduce([check_rank, MPI.INT], [check_result, MPI.INT], op=MPI.SUM)
         tot = np.sum(check_result)
         if tot > 1:
             msg = "When setting data with [] notation, there were "
@@ -504,7 +504,7 @@ class MPIShared(object):
                     nodedata = np.zeros(datashape, dtype=self._dtype)
 
                 # Broadcast the data buffer
-                self._rankcomm.Bcast((nodedata, self._mpitype), root=fromnode)
+                self._rankcomm.Bcast([nodedata, self._mpitype], root=fromnode)
 
                 # Now one process on every node has a copy of the data, and
                 # can copy it into the shared memory buffer.

--- a/test_scripts/shmem_segments.py
+++ b/test_scripts/shmem_segments.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+from mpi4py import MPI
+
+import sys
+import os
+
+import subprocess as sp
+
+import numpy as np
+
+from pshmem import MPIShared
+
+
+def shmem_stat(msg, limits=False):
+    spalloc = sp.check_output(["ipcs", "-m"], universal_newlines=True)
+    n_segment = len(spalloc.split("\n")) - 5
+    if limits:
+        spout = sp.check_output(["ipcs", "-lm"], universal_newlines=True)
+        msg += ":\n"
+        for line in spout.split("\n")[2:-2]:
+            msg += f"  {line}\n"
+        msg += f"  {n_segment} allocated segments"
+        print(f"{msg}")
+    else:
+        print(f"{msg}:  {n_segment} allocated segments")
+
+
+def main():
+    comm = MPI.COMM_WORLD
+    procs = comm.size
+    rank = comm.rank
+
+    shmem_stat(f"Proc {rank} Starting state", limits=True)
+
+    # Create the split communicators that we will re-use.
+    nodecomm = comm.Split_type(MPI.COMM_TYPE_SHARED, 0)
+    noderank = nodecomm.rank
+    nodeprocs = nodecomm.size
+    nodes = procs // nodeprocs
+    if nodes * nodeprocs < procs:
+        nodes += 1
+    mynode = rank // nodeprocs
+    rankcomm = comm.Split(noderank, mynode)
+
+    shmem_stat(f"Proc {rank} After comm split")
+
+    test = list()
+    for imem in range(100):
+        test.append(
+            MPIShared(
+                (10000,),
+                np.float64,
+                comm,
+                comm_node=nodecomm,
+                comm_node_rank=rankcomm,
+            )
+        )
+        shmem_stat(f"Proc {rank} After allocation {imem}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This allows an `MPIShared` object to be constructed with size zero, which can be useful in some situations.  In this case, call `__getitem__` returns `None` and attempting to set items raises an exception.  This work also includes a fix for specifying the explicit Bcast data types, which produced an error in mpi4py 3.1.1.