### PR TITLE
Switch to using the sysv_ipc module

### DIFF
--- a/pshmem/locking.py
+++ b/pshmem/locking.py
@@ -1,5 +1,5 @@
 ##
-# Copyright (c) 2017-2020, all rights reserved.  Use of this source code
+# Copyright (c) 2017-2024, all rights reserved.  Use of this source code
 # is governed by a BSD license that can be found in the top-level
 # LICENSE file.
 ##

--- a/pshmem/test.py
+++ b/pshmem/test.py
@@ -1,5 +1,5 @@
 ##
-# Copyright (c) 2017-2020, all rights reserved.  Use of this source code
+# Copyright (c) 2017-2024, all rights reserved.  Use of this source code
 # is governed by a BSD license that can be found in the top-level
 # LICENSE file.
 ##

--- a/pshmem/test.py
+++ b/pshmem/test.py
@@ -425,6 +425,19 @@ class ShmemTest(unittest.TestCase):
             except RuntimeError:
                 print("successful raise with no data during set()", flush=True)
 
+    # def test_hang(self):
+    #     # Run this while monitoring memory usage (e.g. with htop) and then
+    #     # do kill -9 on one of the processes to verify that the kernel
+    #     # releases shared memory.
+    #     dims = (200, 1000000)
+    #     dt = np.float64
+    #     shm = MPIShared(dims, dt, self.comm)
+    #     import time
+    #     time.sleep(60)
+    #     shm.close()
+    #     del shm
+    #     return
+
 
 class LockTest(unittest.TestCase):
     def setUp(self):

--- a/pshmem/utils.py
+++ b/pshmem/utils.py
@@ -1,10 +1,13 @@
 ##
-# Copyright (c) 2017-2020, all rights reserved.  Use of this source code
+# Copyright (c) 2017-2024, all rights reserved.  Use of this source code
 # is governed by a BSD license that can be found in the top-level
 # LICENSE file.
 ##
 
+import random
+
 import numpy as np
+import sysv_ipc
 
 
 def mpi_data_type(comm, dt):
@@ -42,3 +45,20 @@ def mpi_data_type(comm, dt):
             raise
         dsize = mpitype.Get_size()
     return (dsize, mpitype)
+
+
+def random_shm_key():
+    """Get a random 64bit integer in the range supported by shmget()
+
+    The python random library is used, and seeded with the default source
+    (either system time or os.urandom).
+
+    Returns:
+        (int):  The random integer.
+
+    """
+    min_val = sysv_ipc.KEY_MIN
+    max_val = sysv_ipc.KEY_MAX
+    # Seed with default source of randomness
+    random.seed(a=None)
+    return random.randint(min_val, max_val)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     scripts=None,
     license="BSD",
     python_requires=">=3.8.0",
-    install_requires=["numpy", "posix_ipc"],
+    install_requires=["numpy", "sysv_ipc"],
     extras_require={"mpi": ["mpi4py>=3.0"]},
     cmdclass=versioneer.get_cmdclass(),
     classifiers=[


### PR DESCRIPTION
The `posix_ipc` module is not packaged on conda-forge.  Switch to using the `sysv_ipc` module which is packaged and more portable.  Note that I separately tried using `multiprocessing.shared_memory.SharedMemory` here, but it does not cleanly free memory if one process segfaults.