### PR TITLE
Use Python SharedMemory as the backend

### DIFF
--- a/pshmem/shmem.py
+++ b/pshmem/shmem.py
@@ -9,7 +9,15 @@ from multiprocessing import shared_memory
 
 import numpy as np
 
-from .utils import mpi_data_type, random_shm_key
+from .utils import (
+    mpi_data_type,
+    random_shm_key,
+    remove_shm_from_resource_tracker,
+)
+
+# Monkey patch resource_tracker.  Remove once upstream CPython
+# changes are merged.
+remove_shm_from_resource_tracker()
 
 
 class MPIShared(object):

--- a/pshmem/test.py
+++ b/pshmem/test.py
@@ -432,9 +432,14 @@ class ShmemTest(unittest.TestCase):
     #     dims = (200, 1000000)
     #     dt = np.float64
     #     shm = MPIShared(dims, dt, self.comm)
+    #     if self.comm is None or self.comm.rank == 0:
+    #         temp = np.ones(dims, dtype=dt)
+    #     else:
+    #         temp = None
+    #     shm.set(temp, fromrank=0)
+    #     del temp
     #     import time
     #     time.sleep(60)
-    #     shm.close()
     #     del shm
     #     return
 

--- a/pshmem/utils.py
+++ b/pshmem/utils.py
@@ -6,6 +6,8 @@
 
 import random
 import sys
+# Import for monkey patching resource tracker
+from multiprocessing import resource_tracker
 
 import numpy as np
 
@@ -62,3 +64,25 @@ def random_shm_key():
     # Seed with default source of randomness
     random.seed(a=None)
     return random.randint(min_val, max_val)
+
+
+def remove_shm_from_resource_tracker():
+    """Monkey-patch multiprocessing.resource_tracker so SharedMemory won't be tracked
+
+    More details at: https://bugs.python.org/issue38119
+    """
+
+    def fix_register(name, rtype):
+        if rtype == "shared_memory":
+            return
+        return resource_tracker._resource_tracker.register(self, name, rtype)
+    resource_tracker.register = fix_register
+
+    def fix_unregister(name, rtype):
+        if rtype == "shared_memory":
+            return
+        return resource_tracker._resource_tracker.unregister(self, name, rtype)
+    resource_tracker.unregister = fix_unregister
+
+    if "shared_memory" in resource_tracker._CLEANUP_FUNCS:
+        del resource_tracker._CLEANUP_FUNCS["shared_memory"]

--- a/pshmem/utils.py
+++ b/pshmem/utils.py
@@ -5,9 +5,9 @@
 ##
 
 import random
+import sys
 
 import numpy as np
-import sysv_ipc
 
 
 def mpi_data_type(comm, dt):
@@ -48,7 +48,7 @@ def mpi_data_type(comm, dt):
 
 
 def random_shm_key():
-    """Get a random 64bit integer in the range supported by shmget()
+    """Get a random positive integer for using in shared memory naming.
 
     The python random library is used, and seeded with the default source
     (either system time or os.urandom).
@@ -57,8 +57,8 @@ def random_shm_key():
         (int):  The random integer.
 
     """
-    min_val = sysv_ipc.KEY_MIN
-    max_val = sysv_ipc.KEY_MAX
+    min_val = 0
+    max_val = sys.maxsize
     # Seed with default source of randomness
     random.seed(a=None)
     return random.randint(min_val, max_val)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     scripts=None,
     license="BSD",
     python_requires=">=3.8.0",
-    install_requires=["numpy", "sysv_ipc"],
+    install_requires=["numpy"],
     extras_require={"mpi": ["mpi4py>=3.0"]},
     cmdclass=versioneer.get_cmdclass(),
     classifiers=[


### PR DESCRIPTION
Since Python 3.8, we can use the built-in `SharedMemory` class rather sysv-ipc for portability.  One downside is a [long-standing issue / bug](https://bugs.python.org/issue38119) in CPython that must be worked around.  However, this change now allows tests to work on MacOS.