### PR TITLE
Prevent errors caused by unregistering memory twice.

### DIFF
--- a/pshmem/registry.py
+++ b/pshmem/registry.py
@@ -20,10 +20,18 @@ class MPISharedRegistry:
         self.reg = dict()
 
     def register(self, name, buffer, noderank):
+        if name in self.reg:
+            msg = f"Buffer {name} already registered on node rank {noderank}"
+            raise RuntimeError(msg)
         self.reg[name] = (buffer, noderank)
 
     def unregister(self, name):
-        del self.reg[name]
+        if name in self.reg:
+            buf, noderank = self.reg[name]
+            buf.close()
+            if noderank == 0:
+                buf.unlink()
+            del self.reg[name]
 
     def cleanup(self):
         for name, (buf, noderank) in self.reg.items():

--- a/pshmem/shmem.py
+++ b/pshmem/shmem.py
@@ -376,12 +376,8 @@ class MPIShared(object):
             del self._flat
         if hasattr(self, "_shmem"):
             if self._shmem is not None:
-                # Unregister the shared memory buffer, since we are about to close it.
+                # Unregister the shared memory buffer and close it.
                 registry.unregister(self._name)
-                self._shmem.close()
-                if self._noderank == 0:
-                    self._shmem.unlink()
-                del self._shmem
                 self._shmem = None
         self._flat = None
         self.data = None


### PR DESCRIPTION
At the time of python program exit, the registry.cleanup() method may be called before the remaining MPIShared objects are deleted. Check that a shared memory buffer exists in the registry before trying to free it.